### PR TITLE
Use enviroment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,33 @@
 # Rofi Ico Finder 
 This reduces the time consuming aspect of searching for an icon as a unicode character.
 
-## Usage   
-`./rofi_fa_ico_finder.sh`, then type your keywords, then "enter" then the symbol should be in your clipboard.   
+## Usage
+`./rofi_fa_ico_finder.sh`, then type your keywords, then "enter" then the symbol should be in your clipboard.
 ![screenshot](./screenshot.png?raw=true)
 
-## Requirements   
-font-awesome installed on your machine (I am not sure about that...)   
-rofi   
-xclip   
+## Requirements
+
+font-awesome installed on your machine (I am not sure about that...)
+
+rofi
+xclip (default, could be changed through environment variable).
+
+## Environment variables
+
+Use the following variables to modify the directory (in case of linking the
+executable to other folder, ie. /usr/local/bin). Also to change the default
+command for copying.
+
+```bash
+# Set to the directory where the repository is forked.
+export ROFI_FA_ICON_DIR="foo/bar"
+# Set to the binary for copying
+export ROFI_FA_ICON_BIN='wl-copy'
+```
 
 ## Internals
 
-It works on a list generated with the python script in this repo taking the [awesome yaml](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/src/icons.yml) of the font-awesome github repository into input. As a consequence, at the moment, only the characters supported by font-awesome is supported by this script. If you made a better list, pull it there :). 
+It works on a list generated with the python script in this repo taking the [awesome yaml](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/src/icons.yml) of the font-awesome github repository into input. As a consequence, at the moment, only the characters supported by font-awesome is supported by this script. If you made a better list, pull it there :).
 
 ## License
 MIT

--- a/rofi_fa_ico_finder.sh
+++ b/rofi_fa_ico_finder.sh
@@ -1,3 +1,14 @@
 #!/bin/sh
-BASEDIR=$(dirname $0)
-cat $BASEDIR/fa_icolist.txt | rofi -dmenu -i -p "icon:" | cut -d ' ' -f 2 | xclip -selection clipboard
+if [ -z "$ROFI_FA_ICON_DIR" ]; then
+    BASEDIR=$(dirname $0)
+else
+    BASEDIR="$ROFI_FA_ICON_DIR"
+fi
+
+if [ -z "$ROFI_FA_ICON_BIN" ]; then
+    BIN='xclip -selection clipboard'
+else
+    BIN="$ROFI_FA_ICON_BIN"
+fi
+
+cat ${BASEDIR}/fa_icolist.txt | rofi -dmenu -i -p "Icon" | cut -d ' ' -f 2 | "${ROFI_FA_ICON_BIN}"


### PR DESCRIPTION
Allow to set a source directory in case the executable is linked somewhere else, and also changing the copying command from xclip to something else, without modifiying the script.